### PR TITLE
Update to giphy sdk 2.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,6 +60,7 @@ android {
 repositories {
     // ref: https://www.baeldung.com/maven-local-repository
     mavenLocal()
+    mavenCentral()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
@@ -75,7 +76,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.giphy.sdk:ui:1.1.2'
+    implementation 'com.giphy.sdk:ui:2.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.facebook.fresco:animated-gif:2.1.0"

--- a/android/src/main/java/com/reactnativegiphykeyboard/GiphyModule.kt
+++ b/android/src/main/java/com/reactnativegiphykeyboard/GiphyModule.kt
@@ -8,10 +8,9 @@ import com.giphy.sdk.core.models.Media
 import com.giphy.sdk.core.models.enums.RenditionType
 import com.giphy.sdk.ui.GPHContentType
 import com.giphy.sdk.ui.GPHSettings
-import com.giphy.sdk.ui.GiphyCoreUI
-import com.giphy.sdk.ui.themes.DarkTheme
+import com.giphy.sdk.ui.Giphy
+import com.giphy.sdk.ui.themes.GPHTheme
 import com.giphy.sdk.ui.themes.GridType
-import com.giphy.sdk.ui.themes.LightTheme
 import com.giphy.sdk.ui.utils.imageWithRenditionType
 import com.giphy.sdk.ui.views.GiphyDialogFragment
 
@@ -59,7 +58,7 @@ class GiphyModule(private val reactContext: ReactApplicationContext) : ReactCont
             false
         }
 
-        GiphyCoreUI.configure(reactContext, apiKey, verificationMode)
+        Giphy.configure(reactContext, apiKey, verificationMode)
     }
 
     override fun getName(): String = "RNGiphyKeyboard"
@@ -81,8 +80,8 @@ class GiphyModule(private val reactContext: ReactApplicationContext) : ReactCont
                     GridType.valueOf(gridType ?: DEFAULT_GRID_TYPE)
                 }
                 theme = when (getStringSafe("theme")) {
-                    "dark" -> DarkTheme
-                    else -> LightTheme
+                    "dark" -> GPHTheme.Dark
+                    else -> GPHTheme.Light
                 }
             }
 
@@ -109,7 +108,7 @@ class GiphyModule(private val reactContext: ReactApplicationContext) : ReactCont
             fileType: String = DEFAULT_FILE_TYPE
     ) = object : GiphyDialogFragment.GifSelectionListener {
 
-        override fun onGifSelected(media: Media) {
+        override fun onGifSelected(media: Media, searchTerm: String?, selectedContentType: GPHContentType) {
             val image = media.imageWithRenditionType(RenditionType.valueOf(rendition)) ?: return
             val aspectRatio = image.width / image.height.toDouble()
             val url = when (fileType) {
@@ -129,10 +128,14 @@ class GiphyModule(private val reactContext: ReactApplicationContext) : ReactCont
             reactContext.sendEvent(MEDIA_SELECTED_EVENT, body)
         }
 
-        override fun onDismissed() {
+        override fun onDismissed(selectedContentType: GPHContentType) {
             giphyDialog = null
 
             reactContext.sendEvent(GIPHY_DISMISSED_EVENT)
+        }
+        
+        override fun didSearchTerm(term: String) {
+
         }
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -117,7 +117,7 @@ def jscFlavor = 'org.webkit:android-jsc:+'
  * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
  * and the benefits of using Hermes will therefore be sharply reduced.
  */
-def enableHermes = project.ext.react.get("enableHermes", false);
+def enableHermes = project.ext.react.get("enableHermes", false)
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -181,9 +181,10 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
     if (enableHermes) {
-        def hermesPath = "../../node_modules/hermes-engine/android/";
+        def hermesPath = "../../node_modules/hermes-engine/android/"
         debugImplementation files(hermesPath + "hermes-debug.aar")
         releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         kotlin_version = "1.3.61"
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }
@@ -31,10 +31,6 @@ allprojects {
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
-        }
-
-        maven {
-            url "http://giphy.bintray.com/giphy-sdk"
         }
 
         google()


### PR DESCRIPTION
Refactored GiphyModule.kt to use the 2.1.0 Giphy SDK. I ran into issues when running the example project as part of this repo and the simplest fix, without required additional libraries was the bump the minSDKVersion from 16 to 21. That change also seems to have necessitated that I include androidx.swiperefreshlayout.

### Notes
- I made these changes solely so that I may use them for my own project and did not ensure that it is robust. With that being said, there is one bug that I know of, which is that regardless of which mediaTypes are specified the options in your react-native project, the Giphy keyboard will always default to gifs (even if they're excluded from the selection when opening the Giphy keyboard).
- I could not test on iOS since I don't have access to an iOS device, although I made no changes to any iOS related files.